### PR TITLE
Renamed before targets to prevent name clash

### DIFF
--- a/src/DnnPackager/tools/after.solutionname.sln.targets
+++ b/src/DnnPackager/tools/after.solutionname.sln.targets
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(SolutionDir)\.build\</MSBuildCommunityTasksPath>
+    <NuGetOuputDirectory>$(SolutionDir)</NuGetOuputDirectory>
   </PropertyGroup>
   <Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.targets"/>
 
@@ -37,8 +38,8 @@
     <Message Importance="high" Text="NuGet Solution Package version number is $(SolutionPackageVersionNumber)"/>
     <Message Importance="high" Text="Package output directory is $(SolutionBuildPackagesFolder)"/>
     <PropertyGroup>
-      <SolutionPackCommand>"$(NuGetExeFilePath)" pack "$(PackagingSolutionNuspecFilePath)" -Properties "Configuration=$(Configuration);Platform=$(Platform);PackagePath=$(SolutionBuildPackagesFolder)\;" $(NonInteractiveSwitch) -Version "$(SolutionPackageVersionNumber)" -Verbose</SolutionPackCommand>
-      <SolutionPushCommand>"$(NuGetExeFilePath)" push *.nupkg $(PushSolutionPackagesApiKey) -s $(PushSolutionPackageTo) </SolutionPushCommand>
+      <SolutionPackCommand>"$(NuGetExeFilePath)" pack "$(PackagingSolutionNuspecFilePath)" -Properties "Configuration=$(Configuration);Platform=$(Platform);PackagePath=$(SolutionBuildPackagesFolder)\;" $(NonInteractiveSwitch) -Version "$(SolutionPackageVersionNumber)" -OutputDirectory $(NuGetOuputDirectory) -Verbose</SolutionPackCommand>
+      <SolutionPushCommand>"$(NuGetExeFilePath)" push $(NuGetOuputDirectory)\*.nupkg $(PushSolutionPackagesApiKey) -s $(PushSolutionPackageTo) </SolutionPushCommand>
     </PropertyGroup>
     <Message Importance="high" Text="Build command is $(SolutionPackCommand)"/>
     <Message Importance="high" Text="Push command is $(SolutionPushCommand)"/>

--- a/src/DnnPackager/tools/before.solutionname.sln.targets
+++ b/src/DnnPackager/tools/before.solutionname.sln.targets
@@ -15,12 +15,12 @@
     <CreateSolutionDeploymentPackage Condition="$(CreateSolutionDeploymentPackage) == ''">false</CreateSolutionDeploymentPackage>
   </PropertyGroup>
 
-  <Target Name="CreateSolutionLevelDnnPackage" AfterTargets="Build" Condition="$(CreateSolutionDeploymentPackage)" DependsOnTargets="CleanPackages;" >
+  <Target Name="PreCreateSolutionLevelDnnPackage" BeforeTargets="Build" Condition="$(CreateSolutionDeploymentPackage)" DependsOnTargets="PreCleanPackages;" >
     <Message Text="Running pre build targets" Importance="High">
     </Message>
   </Target>
 
-  <Target Name="CleanPackages">
+  <Target Name="PreCleanPackages">
     <Message Text="Removing directory $(SolutionBuildPackagesFolder)" Importance="High">
     </Message>
     <RemoveDir Directories="$(SolutionBuildPackagesFolder)" />


### PR DESCRIPTION
This is a solution to issue #5.

The problem is because the Before and After targets are the same name. Also, they are both set to run after the build.