### PR TITLE
Add support for SPA and MVC module development

### DIFF
--- a/src/DnnPackager/content/manifest.dnn
+++ b/src/DnnPackager/content/manifest.dnn
@@ -38,7 +38,7 @@
                   <moduleControl>
                     <controlKey>
                     </controlKey>
-                    <controlSrc>DesktopModules/[FolderName]/[YourPathToDefaultView].ascx</controlSrc>
+                    <controlSrc>[YourControllerOrPathToView]/[YourViewFileName].[YourViewFileExtension]</controlSrc>
                     <supportsPartialRendering>False</supportsPartialRendering>
                     <controlTitle>[Default title when added to page]</controlTitle>
                     <controlType>View</controlType>
@@ -47,7 +47,7 @@
                   </moduleControl>
                   <moduleControl>
                     <controlKey>settings</controlKey>
-                    <controlSrc>DesktopModules/[FolderName]/[YourPathToSettings].ascx</controlSrc>
+                    <controlSrc>[YourControllerOrPathToSettings]/[YourSettingsFileName].[YourSettingsFileExtension]</controlSrc>
                     <supportsPartialRendering>False</supportsPartialRendering>
                     <controlTitle>[Default settings title]</controlTitle>
                     <controlType>View</controlType>


### PR DESCRIPTION
Essentially the only thing that changes in the DNN manifest for SPA and MVC modules in DNN 8 are the controlSrc tags.  ASCX files are no longer the only options.  See the following for reference:

**SPA**
* https://github.com/jbrinkman/DNN8Templates/blob/master/src/DnnSpaModule/DnnSpaModule.dnn

**MVC**
* https://github.com/jbrinkman/DNN8Templates/blob/master/src/DnnMvcModule/DnnMvcModule.dnn